### PR TITLE
Remove blocking from RouterDriverActor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,11 @@ val slickVersion = "2.1.0"
 val activeSlickVersion = "0.2.2"
 val postgresVersion = "9.1-901.jdbc4"
 
+
+val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
+val scalaTest = "org.scalatest" %% "scalatest" % scalatestVersion
+
+
 // Force scala version for the dependencies
 dependencyOverrides in ThisBuild ++= Set(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
@@ -138,7 +143,11 @@ lazy val pulse_driver = project.settings(bintraySetting: _*).settings(
 
 lazy val router_driver = project.settings(bintraySetting: _*).settings(
   description := "Enables Vamp to talk to Vamp Router",
-  name:="core-router_driver"
+  name:="core-router_driver",
+  libraryDependencies ++= Seq(
+    scalaTest % "test",
+    akkaTestkit % "test"
+  )
 ).dependsOn(model).disablePlugins(sbtassembly.AssemblyPlugin)
 
 lazy val container_driver = project.settings(bintraySetting: _*).settings(

--- a/router_driver/src/main/scala/io/vamp/core/router_driver/RouterDriverActor.scala
+++ b/router_driver/src/main/scala/io/vamp/core/router_driver/RouterDriverActor.scala
@@ -30,6 +30,7 @@ object RouterDriverActor extends ActorDescription {
 
 }
 
+// TODO: This class is kept as reference and show that the test succeeds with the old implementeation and the new one. It should be deleted once reviewed and accepted.
 class RouterDriverActorOld(driver: RouterDriver) extends Actor with ActorLogging with ActorSupport with ReplyActor with FutureSupportNotification with ActorExecutionContextProvider with RouterDriverNotificationProvider {
 
   import io.vamp.core.router_driver.RouterDriverActor._

--- a/router_driver/src/test/scala/io/vamp/core/router_driver/NewImplementationRouterDriverActorSpec.scala
+++ b/router_driver/src/test/scala/io/vamp/core/router_driver/NewImplementationRouterDriverActorSpec.scala
@@ -1,0 +1,3 @@
+package io.vamp.core.router_driver
+
+class NewImplementationRouterDriverActorSpec extends RouterDriverActorSpec(RouterDriverActorSpec.NewImplementation, "NewImplementationRouterDriverActorSpec")

--- a/router_driver/src/test/scala/io/vamp/core/router_driver/OldImplementationRouterDriverActorSpec.scala
+++ b/router_driver/src/test/scala/io/vamp/core/router_driver/OldImplementationRouterDriverActorSpec.scala
@@ -1,0 +1,3 @@
+package io.vamp.core.router_driver
+
+class OldImplementationRouterDriverActorSpec extends RouterDriverActorSpec(RouterDriverActorSpec.OldImplementation, "OldImplementationRouterDriverActorSpec")

--- a/router_driver/src/test/scala/io/vamp/core/router_driver/RouterDriverActorSpec.scala
+++ b/router_driver/src/test/scala/io/vamp/core/router_driver/RouterDriverActorSpec.scala
@@ -1,0 +1,121 @@
+package io.vamp.core.router_driver
+
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.ConfigFactory
+import io.vamp.common.notification.NotificationErrorException
+import io.vamp.common.vitals.InfoRequest
+import io.vamp.core.model.artifact.{Deployment, DeploymentCluster, Port}
+import io.vamp.core.router_driver.notification.{RouterResponseError, UnsupportedRouterDriverRequest}
+import org.scalatest.concurrent.{Futures, ScalaFutures}
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+
+import scala.concurrent.Future
+
+object RouterDriverActorSpec {
+  sealed trait ImplementationVersionUnderTest
+  case object NewImplementation extends ImplementationVersionUnderTest
+  case object OldImplementation extends ImplementationVersionUnderTest
+}
+
+abstract class RouterDriverActorSpec(version: RouterDriverActorSpec.ImplementationVersionUnderTest, _system: ActorSystem) extends TestKit(_system) with ImplicitSender with WordSpecLike with Matchers with Futures with ScalaFutures with BeforeAndAfterEach {
+  import RouterDriverActorSpec._
+  def this(version: RouterDriverActorSpec.ImplementationVersionUnderTest, actorSystemName: String) = this(version, ActorSystem(actorSystemName, ConfigFactory.parseString("vamp.core.router-driver.response-timeout = 10")))
+  val services = List(RouteService("foo", 100, List(Server("name", "host", 123)), Nil))
+  val clusterRoutes = List(ClusterRoute({(x,y,z)=>true},1243, services))
+  val endpointRoutes: List[EndpointRoute] = List(EndpointRoute({(a,b) => true}, 23323, services))
+  val deploymentRoutes = DeploymentRoutes(clusterRoutes, endpointRoutes)
+  val exception = new scala.IllegalArgumentException("wrong")
+
+  var error = false
+
+  override def beforeEach() = {
+    error = false
+  }
+
+  val driver: RouterDriver = new RouterDriver {
+
+    def all: Future[DeploymentRoutes] = if(error) Future.failed(exception) else Future.successful(deploymentRoutes)
+    def remove(deployment: Deployment, cluster: DeploymentCluster, port: Port): Future[Any] = if(error) Future.failed(exception) else Future.successful("removed")
+    def remove(deployment: Deployment, port: Port): Future[Any] = if(error) Future.failed(exception) else Future.successful("removed2")
+    def info: Future[Any] = if(error) Future.failed(exception) else Future.successful("info")
+    def create(deployment: Deployment, cluster: DeploymentCluster, port: Port, update: Boolean): Future[Any] = if(error) Future.failed(exception) else Future.successful("create")
+    def create(deployment: Deployment, port: Port, update: Boolean): Future[Any] = if(error) Future.failed(exception) else Future.successful("create2")
+  }
+  val actor = version match {
+    case NewImplementation => system.actorOf(Props(new RouterDriverActor(driver)))
+    case OldImplementation => system.actorOf(Props(new RouterDriverActorOld(driver)))
+  }
+
+  val deployment: Deployment = Deployment("someDeploy", List(DeploymentCluster("cluster1",Nil, None, Map.empty, Map.empty)), Nil, Nil, Nil, Nil, Nil)
+  val cluster: DeploymentCluster = DeploymentCluster("deployCluster", Nil, None, Map.empty, Map.empty)
+  val port = Port.portFor(231)
+
+  "RouterDriverActor" should {
+    "reply on inforRequest by calling driver" in {
+      actor ! InfoRequest
+      expectMsg("info")
+    }
+    "reply on inforRequest by calling driver error" in {
+      error = true
+      actor ! InfoRequest
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "handle remove" in {
+      actor ! RouterDriverActor.Remove(deployment, cluster, port)
+      expectMsg("removed")
+    }
+    "handle remove error" in {
+      error = true
+      actor ! RouterDriverActor.Remove(deployment, cluster, port)
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "handle removeEndpoint" in {
+      actor ! RouterDriverActor.RemoveEndpoint(deployment, port)
+      expectMsg("removed2")
+    }
+    "handle removeEndpoint error" in {
+      error = true
+      actor ! RouterDriverActor.RemoveEndpoint(deployment, port)
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "handle Create" in {
+      actor ! RouterDriverActor.Create(deployment, cluster, port, true)
+      expectMsg("create")
+    }
+    "handle Create error" in {
+      error = true
+      actor ! RouterDriverActor.Create(deployment, cluster, port, true)
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "handle CreateEndpoint" in {
+      actor ! RouterDriverActor.CreateEndpoint(deployment, port, true)
+      expectMsg("create2")
+    }
+    "handle CreateEndpoint error" in {
+      error = true
+      actor ! RouterDriverActor.CreateEndpoint(deployment, port, true)
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "handle All" in {
+      actor ! RouterDriverActor.All
+      expectMsg(deploymentRoutes)
+    }
+    "handle All error" in {
+      error = true
+      actor ! RouterDriverActor.All
+      expectMsg(NotificationErrorException(RouterResponseError(exception), "Router response error."))
+    }
+    "give unsupportedOperation" in {
+      case class NotExpected(msg: String)
+      actor ! NotExpected("foo")
+      val msg = expectMsgType[akka.actor.Status.Failure]
+      val notificationErrorException = msg.cause.asInstanceOf[NotificationErrorException]
+      notificationErrorException.message should be ("Unsupported router driver request.")
+      notificationErrorException.notification shouldBe UnsupportedRouterDriverRequest(NotExpected("foo"))
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
As mentioned in issue #6 (and https://github.com/magneticio/vamp-common/issues/4) using `offload` makes the call blocking. This commit shows how to process the call without blocking.